### PR TITLE
fix(local-install): add crossplane helm repo

### DIFF
--- a/local-install.sh
+++ b/local-install.sh
@@ -46,6 +46,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/cont
 kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s 
 
 # install crossplane
+helm repo add crossplane-stable https://charts.crossplane.io/stable
 helm upgrade --install crossplane --namespace crossplane-system --create-namespace crossplane-stable/crossplane --set args='{--enable-external-secret-stores}' --wait
 
 # install vault ess plugin


### PR DESCRIPTION
The install script assumes that the user already has the helm repo for Crossplane added. This fixes that to add it for them. The command is idempotent, so it will have no effect if the user already has it.