### PR TITLE
ci: add workflow to release configuration package

### DIFF
--- a/.github/workflows/release-configuration.yaml
+++ b/.github/workflows/release-configuration.yaml
@@ -1,0 +1,52 @@
+
+name: Release Crossplane Configuration
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  CROSSPLANE_VERSION: v1.14.4
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Fetch Package Tag
+        run: echo "VERSION_TAG=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
+        id: tag
+      
+      - name: Log into ${{ env.REGISTRY }}
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install crossplane CLI
+        run: |
+          curl -Lo /usr/local/bin/crossplane "https://releases.crossplane.io/stable/${{ env.CROSSPLANE_VERSION }}/bin/linux_amd64/crank" \
+          && chmod +x /usr/local/bin/crossplane
+      
+      - name: Build Configuration Package
+        run: |
+          crossplane xpkg build --package-root=crossplane/ -o crossplane/back-stack.xpkg
+      
+      - name: Push ${{ steps.tag.outputs.VERSION_TAG }} & latest
+        run: |
+          crossplane xpkg push -f crossplane/back-stack.xpkg ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-configuration:${{ steps.tag.outputs.VERSION_TAG }}
+          crossplane xpkg push -f crossplane/back-stack.xpkg ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-configuration:latest

--- a/local-install.sh
+++ b/local-install.sh
@@ -61,7 +61,7 @@ kubectl apply -f - <<-EOF
     metadata:
       name: back-stack
     spec:
-      package: ghcr.io/back-stack/showcase-configuration:v0.5.0
+      package: ghcr.io/back-stack/showcase-configuration:latest
 EOF
 
 


### PR DESCRIPTION
This workflow will create a new Crossplane `Configuration` package release with a commit SHA and `latest` tag for each commit to `main`.

- It downloads the CLI directly as `crossplane-contrib/xpkg-action` is broken and unmaintained.
- It uses the workflow permissions to access the repo's packages.
- It will release with the same name as the existing image: `showcase-configuration`.