### PR TITLE
feat(devct): add container to test backstack

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,59 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/ubuntu/.devcontainer/base.Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-ubuntu-22.04
+
+# Select desired TAG from https://github.com/argoproj/argo-cd/releases
+ENV ARGOCD_VERSION=v2.9.3
+RUN curl -sSL -o /usr/local/bin/argocd "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64" \
+    && chmod +x /usr/local/bin/argocd
+
+# Same K8s version that kind creates.
+ENV KUBECTL_VERSION=v1.27.3
+RUN curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    && chmod +x /usr/local/bin/kubectl
+
+# https://github.com/helm/helm/releases
+ENV HELM_VERSION=v3.13.2
+RUN curl -Lo /tmp/helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \
+    && tar -xvf /tmp/helm.tar.gz -C /tmp \
+    && mv /tmp/linux-amd64/helm /usr/local/bin/helm \
+    && chmod +x /usr/local/bin/helm
+
+# https://releases.crossplane.io/stable/
+ENV CROSSPLANE_VERSION=v1.14.4
+RUN curl -Lo /usr/local/bin/crossplane "https://releases.crossplane.io/stable/${CROSSPLANE_VERSION}/bin/linux_amd64/crank" \
+    && chmod +x /usr/local/bin/crossplane
+
+# Used for Backstage development.
+ENV NODE_MAJOR=18
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y nodejs \
+    && npm install --global yarn
+
+# https://github.com/kubernetes-sigs/kustomize/releases
+ENV KUSTOMIZE_VERSION=v5.3.0
+RUN curl -Lo /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
+    && tar -xvf /tmp/kustomize.tar.gz -C /tmp \
+    && mv /tmp/kustomize /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize
+
+ENV YQ_VERSION=v4.40.5
+RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz -O - | tar xz \
+    && mv yq_linux_amd64 /usr/bin/yq
+
+RUN apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN mkdir /usr/local/etc/bash_completion.d
+
+USER vscode
+
+ENV PORTER_VERSION="v1.0.14"
+RUN curl -L https://cdn.porter.sh/$PORTER_VERSION/install-linux.sh | bash
+RUN echo 'PATH="$HOME/.porter:$PATH"' >> ~/.profile \
+    && porter completion bash | sudo tee /usr/local/etc/bash_completion.d/porter
+
+RUN echo alias k=kubectl >> ~/.bashrc \
+    && mkdir ~/.kube

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/kubernetes-helm-minikube
+{
+	"name": "back-stack/showcase",
+	// Use a Dockerfile or Docker Compose file.
+	// https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"enableNonRootDocker": "true",
+			"moby": "true"
+		}
+	},
+	
+	"hostRequirements": {
+		"cpus": 4
+	},
+
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"files.insertFinalNewline": true,
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"github.vscode-github-actions",
+			]
+		}
+	},
+
+	// Use 'postCreateCommand' to run commands everytime the container is created.
+	"postCreateCommand": "/bin/bash -c .devcontainer/post-create.sh",
+
+	// Use 'postStartCommand' to run commands everytime the container is started.
+	"postStartCommand": "/bin/bash -c .devcontainer/post-start.sh"
+
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "post-create start" >> ~/status
+
+# This runs each time the container is created.
+
+echo "post-create complete" >> ~/status

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "post-start start" >> ~/status
+
+# This runs each time the container starts.
+
+echo "post-start complete" >> ~/status


### PR DESCRIPTION
Provide a [devcontainer](https://containers.dev/) for users to run the `porter install`, try out the BACK stack, and for testing during development. Removes the need for dependencies on the local system (besides docker, and a devcontainer runtime like vscode or devpod). Includes all the tooling for testing like NodeJS (for backstage) and `kustomize`.

Users won't have to use this, but it adds the option that someone could test out the BACK stack right in the GitHub Codespaces.

I set the target branch to `porter-installer` as this includes `porter`. If that gets merged first, this will then target `main`.