### PR TITLE
ci(release): remove force flag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Push the image
         run: |
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backstage:${{ steps.tag.outputs.VERSION_TAG }}
-          docker push --force ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backstage:latest
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backstage:latest
   
   bundle:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes: https://github.com/back-stack/showcase/actions/runs/7905805813/job/21579220510#step:9:47
```
docker push --force ghcr.io/back-stack/showcase-backstage:latest
unknown flag: --force
```
