### PR TITLE
fix: rename repo secret

### DIFF
--- a/bundle/helpers.sh
+++ b/bundle/helpers.sh
@@ -50,7 +50,7 @@ deploy_secrets() {
     apiVersion: v1
     kind: Secret
     metadata:
-      name: clusters
+      name: clusters-repository
       namespace: argocd
       labels:
         argocd.argoproj.io/secret-type: repository


### PR DESCRIPTION
Rename to reflect it's purpose as a repo secret, avoiding confusion with a "cluster" secret. The name change should **not** affect any references to it, since it's based on the repoURL, not the name.