### PR TITLE
Fix secrets

### DIFF
--- a/bundle/helpers.sh
+++ b/bundle/helpers.sh
@@ -80,9 +80,8 @@ EOF
     metadata:
       name: azure-secret
       namespace: crossplane-system
-    stringData:
-      credentials: |
-        ${AZURE_CREDENTIALS}
+    data:
+      credentials: $(echo "${AZURE_CREDENTIALS}" | base64)
 EOF
 
   kubectl apply -f - <<-EOF
@@ -91,9 +90,8 @@ EOF
     metadata:
       name: aws-secret
       namespace: crossplane-system
-    stringData:
-      credentials: |
-        ${AWS_CREDENTIALS}
+    data:
+      credentials: $(echo "${AWS_CREDENTIALS}" | base64)
 EOF
 }
 

--- a/bundle/helpers.sh
+++ b/bundle/helpers.sh
@@ -81,7 +81,7 @@ EOF
       name: azure-secret
       namespace: crossplane-system
     data:
-      credentials: $(echo "${AZURE_CREDENTIALS}" | base64)
+      credentials: $(echo -n "${AZURE_CREDENTIALS}" | base64 -w 0)
 EOF
 
   kubectl apply -f - <<-EOF
@@ -91,7 +91,7 @@ EOF
       name: aws-secret
       namespace: crossplane-system
     data:
-      credentials: $(echo "${AWS_CREDENTIALS}" | base64)
+      credentials: $(echo -n "$AWS_CREDENTIALS" | base64 -w 0)
 EOF
 }
 


### PR DESCRIPTION
the script that was creating aws and azure secrets was combining heredoc with variable expansion and yaml, a recipe for indentation-related sadness.

Updated the script to pre-hash everything in base64